### PR TITLE
fix: random failures that frequently happens when running integration tests

### DIFF
--- a/tests/integration/tests.ts
+++ b/tests/integration/tests.ts
@@ -1,4 +1,4 @@
-import { getVerificationResult, waitForEndpoint } from "./util.ts";
+import { waitForEndpoint } from "./util.ts";
 import * as Colors from "https://deno.land/std@0.95.0/fmt/colors.ts";
 
 console.log("trying to cleanup prev run");
@@ -127,7 +127,7 @@ Deno.writeTextFileSync(
 
 
 console.log(Colors.blue("starting verification scenario.."));
-Deno.run({
+const verificationScenario = Deno.run({
   env: {
     "BEARER_TOKEN": jwt,
   },
@@ -144,7 +144,7 @@ Deno.run({
 });
 
 console.log("waiting for Rumpel to be done..");
-const verificationResult = await getVerificationResult();
+const verificationResult = new TextDecoder().decode(await verificationScenario.output());
 console.log("Rumpel verification is done!");
 
 const verificationSucceeded = verificationResult.includes(

--- a/tests/integration/util.ts
+++ b/tests/integration/util.ts
@@ -20,32 +20,3 @@ export const waitForEndpoint = async (url: string): Promise<void> => {
     return waitForEndpoint(url);
   }
 };
-export const getVerificationResult = async (): Promise<string> => {
-  const watchRumpel = Deno.run({
-    cmd: [
-      "docker",
-      "inspect",
-      "integration_rumpel_1",
-    ],
-    stdout: "piped",
-    stdin: "piped",
-    stderr: "piped",
-  });
-  const rumpelResult = new TextDecoder().decode(await watchRumpel.output());
-  if (rumpelResult.includes('"Running": false')) {
-    const verificationText = Deno.run({
-      cmd: [
-        "docker",
-        "logs",
-        "integration_rumpel_1",
-      ],
-      stdout: "piped",
-      stdin: "piped",
-      stderr: "piped",
-    });
-    return new TextDecoder().decode(await verificationText.output());
-  } else {
-    await sleep(1000);
-    return getVerificationResult();
-  }
-};


### PR DESCRIPTION
fix: random failures that frequently happens when running integration tests, during the verification scenario. 

a guess is that the getVerificationResult() method might have an underlying race condition, since the random failure always correlated with the `docker logs integration_rumpel_1` command returning an empty log (empty string).

this PR instead awaits the output of the verificationScenario and passes that to the verificationSucceded logic.